### PR TITLE
AWS Email service to use separate user from AWS S3 service

### DIFF
--- a/context/aws/index.js
+++ b/context/aws/index.js
@@ -1,4 +1,5 @@
-const awsSDK = require('aws-sdk');
+const awsSDK_S3 = require('aws-sdk');
+const awsSDK_Email = require('aws-sdk');
 const S3 = require('./s3');
 const SES = require('./ses');
 
@@ -6,9 +7,15 @@ const S3_ACCESS_KEY_ID = process.env.S3_ACCESS_KEY_ID;
 const S3_SECRET_ACCESS_KEY = process.env.S3_SECRET_ACCESS_KEY;
 const AWS_REGION = process.env.AWS_REGION || 'ap-southeast-2';
 
-awsSDK.config.update({
+awsSDK_S3.config.update({
   accessKeyId: S3_ACCESS_KEY_ID,
   secretAccessKey: S3_SECRET_ACCESS_KEY,
+  region: AWS_REGION,
+});
+
+awsSDK_Email.config.update({
+  accessKeyId: EMAIL_ACCESS_KEY_ID,
+  secretAccessKey: EMAIL_SECRET_ACCESS_KEY,
   region: AWS_REGION,
 });
 
@@ -20,7 +27,7 @@ const {
   fetchDoc: fetchDocFromS3,
   removeImage: removeImageFromS3,
   removeDoc: removeDocFromS3,
-} = S3(awsSDK);
-const { sendEmail, getDomainIdentities } = SES(awsSDK);
+} = S3(awsSDK_S3);
+const { sendEmail, getDomainIdentities } = SES(awsSDK_Email);
 
 module.exports = { uploadImageToS3, fetchImageFromS3, fetchVideoFromS3, uploadDocToS3, fetchDocFromS3, removeImageFromS3, sendEmail, getDomainIdentities, removeDocFromS3 };

--- a/context/aws/index.js
+++ b/context/aws/index.js
@@ -1,5 +1,5 @@
 const awsSDK_S3 = require('aws-sdk');
-const awsSDK_Email = require('aws-sdk');
+const awsSDK_SES = require('aws-sdk');
 const S3 = require('./s3');
 const SES = require('./ses');
 
@@ -13,9 +13,9 @@ awsSDK_S3.config.update({
   region: AWS_REGION,
 });
 
-awsSDK_Email.config.update({
-  accessKeyId: EMAIL_ACCESS_KEY_ID,
-  secretAccessKey: EMAIL_SECRET_ACCESS_KEY,
+awsSDK_SES.config.update({
+  accessKeyId: SES_ACCESS_KEY_ID,
+  secretAccessKey: SES_SECRET_ACCESS_KEY,
   region: AWS_REGION,
 });
 
@@ -28,6 +28,6 @@ const {
   removeImage: removeImageFromS3,
   removeDoc: removeDocFromS3,
 } = S3(awsSDK_S3);
-const { sendEmail, getDomainIdentities } = SES(awsSDK_Email);
+const { sendEmail, getDomainIdentities } = SES(awsSDK_SES);
 
 module.exports = { uploadImageToS3, fetchImageFromS3, fetchVideoFromS3, uploadDocToS3, fetchDocFromS3, removeImageFromS3, sendEmail, getDomainIdentities, removeDocFromS3 };


### PR DESCRIPTION
This issue originated from changes to the whppt-s3-user IAM user's permissions. This user should not be authorised to send emails, there is already a user responsible for authorising emails.

Projects using whppt's emailer will need to include new environment variables, EMAIL_SECRET_ACCESS_KEY and EMAIL_ACCESS_KEY_ID with this change.