### PR TITLE
aws s3 and ses code separated to fix issue where aws-sdk config is cr…

### DIFF
--- a/context/aws/index.js
+++ b/context/aws/index.js
@@ -1,23 +1,7 @@
-const awsSDK_S3 = require('aws-sdk');
-const awsSDK_SES = require('aws-sdk');
 const S3 = require('./s3');
 const SES = require('./ses');
 
-const S3_ACCESS_KEY_ID = process.env.S3_ACCESS_KEY_ID;
-const S3_SECRET_ACCESS_KEY = process.env.S3_SECRET_ACCESS_KEY;
-const AWS_REGION = process.env.AWS_REGION || 'ap-southeast-2';
-
-awsSDK_S3.config.update({
-  accessKeyId: S3_ACCESS_KEY_ID,
-  secretAccessKey: S3_SECRET_ACCESS_KEY,
-  region: AWS_REGION,
-});
-
-awsSDK_SES.config.update({
-  accessKeyId: SES_ACCESS_KEY_ID,
-  secretAccessKey: SES_SECRET_ACCESS_KEY,
-  region: AWS_REGION,
-});
+const { sendEmail, getDomainIdentities } = SES();
 
 const {
   uploadImage: uploadImageToS3,
@@ -27,7 +11,6 @@ const {
   fetchDoc: fetchDocFromS3,
   removeImage: removeImageFromS3,
   removeDoc: removeDocFromS3,
-} = S3(awsSDK_S3);
-const { sendEmail, getDomainIdentities } = SES(awsSDK_SES);
+} = S3();
 
 module.exports = { uploadImageToS3, fetchImageFromS3, fetchVideoFromS3, uploadDocToS3, fetchDocFromS3, removeImageFromS3, sendEmail, getDomainIdentities, removeDocFromS3 };

--- a/context/aws/s3.js
+++ b/context/aws/s3.js
@@ -1,6 +1,12 @@
 const S3_BUCKET_NAME = process.env.S3_BUCKET;
+const awsSDK = require('aws-sdk');
 
-module.exports = awsSDK => {
+module.exports = () => {
+  awsSDK.config.update({
+    accessKeyId: process.env.S3_ACCESS_KEY_ID,
+    secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
+    region: process.env.AWS_REGION || 'ap-southeast-2',
+  });
   const s3 = new awsSDK.S3();
 
   const uploadImage = function(fileBuffer, id) {

--- a/context/aws/ses.js
+++ b/context/aws/ses.js
@@ -1,4 +1,11 @@
-module.exports = awsSDK => {
+const awsSDK = require('aws-sdk');
+
+module.exports = () => {
+  awsSDK.config.update({
+    accessKeyId: process.env.SES_ACCESS_KEY_ID,
+    secretAccessKey: process.env.SES_SECRET_ACCESS_KEY,
+    region: process.env.AWS_REGION || 'ap-southeast-2',
+  });
   const ses = new awsSDK.SES();
 
   const sendEmail = ({ from, to, subject, html }) => {


### PR DESCRIPTION
After discovering that the config() function from AWS SDK holds shared credentials, the calls to AWS functions were separated into their own files to remove any need to synchronously call config in the right order. Tested changes locally by modifying node_modules, calling S3 upload and calling SES send mail, both are functional. Version 1.14 ought to be depreciated.